### PR TITLE
Windows tomcat context fix 152 in generator-alfresco

### DIFF
--- a/lib/alfresco-module-registry.js
+++ b/lib/alfresco-module-registry.js
@@ -1,5 +1,7 @@
 'use strict';
 var debug = require('debug')('generator-alfresco:alfresco-module-registry');
+var slash = require('slash');
+
 var constants = require('./constants.js');
 
 /**
@@ -50,6 +52,9 @@ var constants = require('./constants.js');
 module.exports = function (yo) {
   var module = {};
   var modules = yo.config.get('moduleRegistry') || [];
+  modules.forEach(mod => {
+    mod.path = slash(mod.path);
+  });
 
   module.getModules = function () {
     return modules;
@@ -88,6 +93,7 @@ module.exports = function (yo) {
         if (modOrGroupId.groupId && modOrGroupId.artifactId
           && modOrGroupId['version'] && modOrGroupId.packaging
           && modOrGroupId.war && modOrGroupId['location'] && modOrGroupId.path) {
+          modOrGroupId.path = slash(modOrGroupId.path);
           debug('returning pre-objectified module: %j', modOrGroupId);
           return modOrGroupId;
         } else {
@@ -107,7 +113,7 @@ module.exports = function (yo) {
           'packaging': packaging,
           'war': war,
           'location': loc,
-          'path': path,
+          'path': slash(path),
         };
       }
     }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lodash": "4.17.4",
     "pretty-data": "0.40.0",
     "semver": "5.3.0",
+    "slash": "1.0.0",
     "split": "1.0.0",
     "window-size": "0.3.0",
     "wrap-ansi": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-alfresco-common",
-  "version": "0.9.5",
+  "version": "0.9.7",
   "description": "Common code for Alfresco yeoman generator",
   "license": "Apache-2.0",
   "main": "index.js",

--- a/test/test-alfresco-module-registry.js
+++ b/test/test-alfresco-module-registry.js
@@ -472,6 +472,52 @@ describe('generator-alfresco:alfresco-module-registry', function () {
       });
     });
   });
+
+  describe('windows paths', function () {
+    it('are converted to posix paths when adding', function () {
+      var repo = require('../index').alfresco_module_registry(yomock);
+      repo.addModule('groupId', 'artifactId', 'version', 'packaging', 'war', 'location', 'customizations\\path');
+      var modules = repo.getModules();
+      assert.ok(modules);
+      assert.deepEqual(modules, [{
+        'groupId': 'groupId',
+        'artifactId': 'artifactId',
+        'version': 'version',
+        'packaging': 'packaging',
+        'war': 'war',
+        'location': 'location',
+        'path': 'customizations/path',
+      }]);
+    });
+
+    it('are converted to posix paths when reading', function () {
+      var persistentyomock = {
+        'config': {
+          'get': key => { return persistentyomock.configData[key] },
+          'set': (key, value) => { persistentyomock.configData[key] = value },
+        },
+        'configData': {},
+        'projectGroupId': 'org.alfresco',
+        'projectVersion': '1.0.0-SNAPSHOT',
+      };
+
+      var repo = require('../index').alfresco_module_registry(persistentyomock);
+      repo.addModule('groupId', 'artifactId', 'version', 'packaging', 'war', 'location', 'customizations\\path');
+      repo.save();
+      repo = require('../index').alfresco_module_registry(persistentyomock);
+      var modules = repo.getModules();
+      assert.ok(modules);
+      assert.deepEqual(modules, [{
+        'groupId': 'groupId',
+        'artifactId': 'artifactId',
+        'version': 'version',
+        'packaging': 'packaging',
+        'war': 'war',
+        'location': 'location',
+        'path': 'customizations/path',
+      }]);
+    });
+  });
 });
 
 // vim: autoindent expandtab tabstop=2 shiftwidth=2 softtabstop=2


### PR DESCRIPTION
	Make alfresco-module-registry use posix paths  …
This attempts to fix windows style paths as they are added to
the module registry. It also performs this repair when reading
the registry.

Technically this is sufficient to address #152 going forward.
However, I still plan to review the use of path.baseline() and
path.join() across the code base to see if we can simply force
POSIX style paths in cases where that will matter.

fixes 152 in generator-alfresco