### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-alfresco-common",
-  "version": "0.9.26",
+  "version": "0.9.27",
   "description": "Common code for Alfresco yeoman generator",
   "license": "Apache-2.0",
   "main": "index.js",
@@ -25,7 +25,7 @@
   "dependencies": {
     "chalk": "2.4.0",
     "cross-spawn": "6.0.5",
-    "deasync": "0.1.12",
+    "deasync": "0.1.14",
     "debug": "3.1.0",
     "deep-extend": "0.5.0",
     "glob": "7.1.2",


### PR DESCRIPTION
https://github.com/Alfresco/alfresco-ng2-components/issues/4074 

Seems to me that "npm install -g generator-alfresco-adf-app@latest" command fails on the latest version of the nodejs (10.14.1 LTS) but then works with previous version 8.x. The error comes from npm package deasync version 0.1.12. NPM could not install the deasync version 0.1.12. From node 10.x, I could install higher version of deasync (0.1.13 or 0.1.14 current) but not the version of 0.1.12